### PR TITLE
Add Next.js rewrite skeleton

### DIFF
--- a/nextjs-rewrite/.gitignore
+++ b/nextjs-rewrite/.gitignore
@@ -1,0 +1,13 @@
+# Dependencies
+/node_modules
+
+# Build output
+/.next
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment variables
+.env*

--- a/nextjs-rewrite/LICENSE
+++ b/nextjs-rewrite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 AspNet Boilerplate contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nextjs-rewrite/README.md
+++ b/nextjs-rewrite/README.md
@@ -1,0 +1,26 @@
+# Next.js Rewrite
+
+Bu klasör, `abp-ng2-module` servislerinin Next.js için uyarlanmis basit bir versiyonunu içerir. Özgün Angular kütüphanesinin tüm özelliklerini kapsamaz fakat Next.js projelerinde temel islevsellik saglamak için bir baslangic noktasi sunar.
+
+## Mevcut Servisler
+
+- `token.ts` – Kimlik dogrulama tokenini çerezlerde saklar ve okur.
+- `permission.ts` – Basit izin kontrolü yardimcisi.
+- `http.ts` – Token bilgisini otomatik ekleyen, basit hata yönetimi yapan `fetch` sarmalaması.
+
+## Kullanım
+
+Projeyi çalıştırmak için:
+
+```bash
+npm install
+npm run dev
+```
+
+`_app.tsx`, `_document.tsx` ve `next.config.js` dosyaları Next.js uygulamasının temel yapılandırması için eklenmiştir.
+
+> **Not**: Bu uyarlama öğretici nitelikte olup tam bir özellik seti sunmaz.
+
+## Lisans
+
+Bu klasör altındaki kod MIT lisansı ile dağıtılmaktadır.

--- a/nextjs-rewrite/next-env.d.ts
+++ b/nextjs-rewrite/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/nextjs-rewrite/next.config.js
+++ b/nextjs-rewrite/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true
+};
+
+module.exports = nextConfig;

--- a/nextjs-rewrite/package.json
+++ b/nextjs-rewrite/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nextjs-rewrite",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.2"
+  }
+}

--- a/nextjs-rewrite/pages/_app.tsx
+++ b/nextjs-rewrite/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/nextjs-rewrite/pages/_document.tsx
+++ b/nextjs-rewrite/pages/_document.tsx
@@ -1,0 +1,15 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}

--- a/nextjs-rewrite/pages/api/hello.ts
+++ b/nextjs-rewrite/pages/api/hello.ts
@@ -1,0 +1,5 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  res.status(200).json({ message: 'Hello from Next.js rewrite!' });
+}

--- a/nextjs-rewrite/pages/index.tsx
+++ b/nextjs-rewrite/pages/index.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { abpFetch, TokenService } from '../src';
+
+export default function Home() {
+  const [data, setData] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    abpFetch('/api/hello')
+      .then(setData)
+      .catch(e => setError(e.message));
+  }, []);
+
+  return (
+    <div>
+      <h1>Next.js Rewrite Example</h1>
+      {error && <p>Error: {error}</p>}
+      {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/nextjs-rewrite/src/index.ts
+++ b/nextjs-rewrite/src/index.ts
@@ -1,0 +1,3 @@
+export { default as TokenService } from './services/token';
+export { default as PermissionChecker } from './services/permission';
+export { abpFetch } from './services/http';

--- a/nextjs-rewrite/src/services/http.ts
+++ b/nextjs-rewrite/src/services/http.ts
@@ -1,0 +1,29 @@
+import TokenService from './token';
+
+export interface AjaxError {
+  message: string;
+  details?: string;
+}
+
+export async function abpFetch(url: string, options: RequestInit = {}): Promise<any> {
+  const headers = new Headers(options.headers || {});
+  const token = TokenService.getToken();
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  const response = await fetch(url, { ...options, headers });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    let parsed: any;
+    try { parsed = JSON.parse(errorBody); } catch { parsed = { message: errorBody }; }
+    throw parsed as AjaxError;
+  }
+
+  const text = await response.text();
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return text;
+  }
+}

--- a/nextjs-rewrite/src/services/permission.ts
+++ b/nextjs-rewrite/src/services/permission.ts
@@ -1,0 +1,8 @@
+export type PermissionMap = Record<string, boolean>;
+
+export const PermissionChecker = {
+  isGranted(permission: string, granted: PermissionMap): boolean {
+    return !!granted[permission];
+  }
+};
+export default PermissionChecker;

--- a/nextjs-rewrite/src/services/token.ts
+++ b/nextjs-rewrite/src/services/token.ts
@@ -1,0 +1,45 @@
+export const TOKEN_COOKIE = 'Abp.AuthToken';
+export const REFRESH_TOKEN_COOKIE = 'Abp.AuthRefreshToken';
+
+function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  return match ? decodeURIComponent(match[2]) : null;
+}
+
+function setCookie(name: string, value: string, expireDate?: Date) {
+  if (typeof document === 'undefined') return;
+  let cookie = `${name}=${encodeURIComponent(value)}`;
+  if (expireDate) {
+    cookie += `; expires=${expireDate.toUTCString()}`;
+  }
+  cookie += '; path=/';
+  document.cookie = cookie;
+}
+
+function deleteCookie(name: string) {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+}
+
+export const TokenService = {
+  getToken(): string | null {
+    return getCookie(TOKEN_COOKIE);
+  },
+  setToken(token: string, expireDate?: Date) {
+    setCookie(TOKEN_COOKIE, token, expireDate);
+  },
+  clearToken() {
+    deleteCookie(TOKEN_COOKIE);
+  },
+  getRefreshToken(): string | null {
+    return getCookie(REFRESH_TOKEN_COOKIE);
+  },
+  setRefreshToken(token: string, expireDate?: Date) {
+    setCookie(REFRESH_TOKEN_COOKIE, token, expireDate);
+  },
+  clearRefreshToken() {
+    deleteCookie(REFRESH_TOKEN_COOKIE);
+  }
+};
+export default TokenService;

--- a/nextjs-rewrite/styles/globals.css
+++ b/nextjs-rewrite/styles/globals.css
@@ -1,0 +1,5 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+  margin: 0;
+  padding: 0;
+}

--- a/nextjs-rewrite/tsconfig.json
+++ b/nextjs-rewrite/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "incremental": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create a `nextjs-rewrite` folder with a minimal Next.js setup
- implement token and permission utilities, a simple HTTP helper, and a demo page
- add MIT license and documentation
- add Next.js config, ignore file and global styles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685088a28e6c832ea4d1b4cbcddd7e2b